### PR TITLE
chore: output test coverage as default

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "jest",
+    "test": "jest --coverage",
     "prerelease": "npm t && npm run lint",
     "release": "standard-version"
   },


### PR DESCRIPTION
This allows the README's coverage badge to be useful.