### PR TITLE
Feature: Add build-time environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Next.js plugin to pass environment variables to Next.js' runtime configuration.
 
 By default, Next.js does not make available `process.env` to the client side. The available solution for this problem is to set a runtime config in `next.config.js` to pass values which will be available in either server and client or just server.
 
-The way to do it is by passing values to the `publicRuntimeConfig` and `serverRuntimeConfig` properties of Next.js' config.
+The way to do it is by passing values to the `publicRuntimeConfig`, `serverRuntimeConfig` and `env` properties of Next.js' config.
+
+*More info: https://nextjs.org/docs#build-time-configuration*
 
 This plugin does that automatically for all environment variables starting with a certain prefix.
 
@@ -53,12 +55,30 @@ module.exports = withCSS(
 );
 ```
 
+Application usage:
+
+```js
+// next.config.js
+const withRuntimeEnv = require('@moxy/next-runtime-env');
+
+module.exports = withRuntimeEnv({ removePrefixes: true })({ ...nextConfig });
+
+// environment variables definition
+PUBLIC_FOO="bar"
+BUILD_BAR="compile-me-please"
+
+// app.js
+const x = process.env.FOO; // "bar"
+const y = "compile-me-please" // original code was `const y = process.env.BAR;
+```
+
 ### API
 
 | Option | Description | Type | Default |
 |---|--------------------------------------------------------------------|---------|-----------|
 | publicPrefix | Prefix of variables to lookup and then pass to publicRuntimeConfig | String | `PUBLIC_` |
 | serverPrefix | Prefix of variables to lookup and then pass to serverRuntimeConfig | String | `SERVER_` |
+| buildPrefix  | Prefix of variables to lookup and then pass to env to be injected in compile-time | String | `BUILD_` |
 | removePrefixes | Option to remove prefix when passing variables to runtime config | Boolean | `false` |
 
 ## Tests
@@ -67,7 +87,6 @@ Any parameter passed to the `test` command, is passed down to Jest.
 
 ```sh
 $ npm t
-$ npm t -- --coverage # to generate coverage report
 $ npm t -- --watch # during development
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,23 +62,27 @@ Application usage:
 const withRuntimeEnv = require('@moxy/next-runtime-env');
 
 module.exports = withRuntimeEnv({ removePrefixes: true })({ ...nextConfig });
+```
 
-// environment variables definition
-PUBLIC_FOO="bar"
-BUILD_BAR="compile-me-please"
+```sh
+# environment variables definition
+NEXT_PUBLIC_FOO="bar"
+NEXT_BUILD_BAR="compile-me-please"
+```
 
+```js
 // app.js
-const x = process.env.FOO; // "bar"
-const y = "compile-me-please" // original code was `const y = process.env.BAR;
+const x = process.env.FOO; // 'bar'
+const y = 'compile-me-please' // original code was `const y = process.env.BAR;
 ```
 
 ### API
 
 | Option | Description | Type | Default |
 |---|--------------------------------------------------------------------|---------|-----------|
-| publicPrefix | Prefix of variables to lookup and then pass to publicRuntimeConfig | String | `PUBLIC_` |
-| serverPrefix | Prefix of variables to lookup and then pass to serverRuntimeConfig | String | `SERVER_` |
-| buildPrefix  | Prefix of variables to lookup and then pass to env to be injected in compile-time | String | `BUILD_` |
+| publicPrefix | Prefix of variables to lookup and then pass to publicRuntimeConfig | String | `NEXT_PUBLIC_` |
+| serverPrefix | Prefix of variables to lookup and then pass to serverRuntimeConfig | String | `NEXT_SERVER_` |
+| buildPrefix  | Prefix of variables to lookup and then pass to env to be injected in compile-time | String | `NEXT_BUILD_` |
 | removePrefixes | Option to remove prefix when passing variables to runtime config | Boolean | `false` |
 
 ## Tests

--- a/index.js
+++ b/index.js
@@ -29,9 +29,9 @@ const buildConfig = (keys, initialConfig, prefix, { removePrefixes }) => {
 
 const runtimeEnv = (options = {}) => (nextConfig = {}) => {
     const {
-        publicPrefix = 'PUBLIC_',
-        serverPrefix = 'SERVER_',
-        buildPrefix = 'BUILD_',
+        publicPrefix = 'NEXT_PUBLIC_',
+        serverPrefix = 'NEXT_SERVER_',
+        buildPrefix = 'NEXT_BUILD_',
         removePrefixes = false,
     } = options;
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const buildRuntimeConfig = (keys, initialConfig, prefix, { removePrefixes }) => {
+const buildConfig = (keys, initialConfig, prefix, { removePrefixes }) => {
     const re = new RegExp(`^${prefix}`, 'i');
 
     const config = keys.reduce((acc, key) => {
@@ -23,6 +23,7 @@ const buildRuntimeConfig = (keys, initialConfig, prefix, { removePrefixes }) => 
  * @param {Object} options
  * @param {String} options.publicPrefix     Prefix of variables to lookup and then pass to publicRuntimeConfig
  * @param {String} options.serverPrefix     Prefix of variables to lookup and then pass to serverRuntimeConfig
+ * @param {String} options.buildPrefix     Prefix of variables to lookup and then pass to buildRuntimeConfig
  * @param {String} options.removePrefixes   Option to remove prefix when passing variables to runtime config
  */
 
@@ -30,20 +31,23 @@ const runtimeEnv = (options = {}) => (nextConfig = {}) => {
     const {
         publicPrefix = 'PUBLIC_',
         serverPrefix = 'SERVER_',
+        buildPrefix = 'BUILD_',
         removePrefixes = false,
     } = options;
 
     let {
         publicRuntimeConfig = {},
         serverRuntimeConfig = {},
+        env = {},
     } = nextConfig;
 
     const envKeys = Object.keys(process.env);
 
-    publicRuntimeConfig = buildRuntimeConfig(envKeys, publicRuntimeConfig, publicPrefix, { removePrefixes });
-    serverRuntimeConfig = buildRuntimeConfig(envKeys, serverRuntimeConfig, serverPrefix, { removePrefixes });
+    publicRuntimeConfig = buildConfig(envKeys, publicRuntimeConfig, publicPrefix, { removePrefixes });
+    serverRuntimeConfig = buildConfig(envKeys, serverRuntimeConfig, serverPrefix, { removePrefixes });
+    env = buildConfig(envKeys, env, buildPrefix, { removePrefixes });
 
-    return { ...nextConfig, publicRuntimeConfig, serverRuntimeConfig };
+    return { ...nextConfig, publicRuntimeConfig, serverRuntimeConfig, env };
 };
 
 module.exports = runtimeEnv;

--- a/index.test.js
+++ b/index.test.js
@@ -9,27 +9,27 @@ afterEach(() => {
 it('should return nextConfig with mocked variables', () => {
     process.env = {
         ...originalEnv,
-        PUBLIC_TEST_FOO: 'foo',
-        SERVER_TEST_BAR: 'bar',
-        BUILD_TEST_ZOO: 'pet',
+        NEXT_PUBLIC_TEST_FOO: 'foo',
+        NEXT_SERVER_TEST_BAR: 'bar',
+        NEXT_BUILD_TEST_ZOO: 'pet',
     };
 
     const plugin = runtimeEnv();
     const nextConfig = plugin();
 
     expect(nextConfig).toEqual({
-        publicRuntimeConfig: { PUBLIC_TEST_FOO: 'foo' },
-        serverRuntimeConfig: { SERVER_TEST_BAR: 'bar' },
-        env: { BUILD_TEST_ZOO: 'pet' },
+        publicRuntimeConfig: { NEXT_PUBLIC_TEST_FOO: 'foo' },
+        serverRuntimeConfig: { NEXT_SERVER_TEST_BAR: 'bar' },
+        env: { NEXT_BUILD_TEST_ZOO: 'pet' },
     });
 });
 
 it('should return nextConfig with mocked variables without prefix', () => {
     process.env = {
         ...originalEnv,
-        PUBLIC_TEST_FOO: 'foo',
-        SERVER_TEST_BAR: 'bar',
-        BUILD_TEST_ZOO: 'pet',
+        NEXT_PUBLIC_TEST_FOO: 'foo',
+        NEXT_SERVER_TEST_BAR: 'bar',
+        NEXT_BUILD_TEST_ZOO: 'pet',
     };
 
     const plugin = runtimeEnv({ removePrefixes: true });
@@ -63,9 +63,9 @@ it('should return nextConfig with mocked variables with new prefixes', () => {
 it('should return nextConfig with mocked variables alongside existing ones', () => {
     process.env = {
         ...originalEnv,
-        PUBLIC_TEST_FOO: 'foo',
-        SERVER_TEST_BAR: 'bar',
-        BUILD_TEST_ZOO: 'pet',
+        NEXT_PUBLIC_TEST_FOO: 'foo',
+        NEXT_SERVER_TEST_BAR: 'bar',
+        NEXT_BUILD_TEST_ZOO: 'pet',
     };
 
     const plugin = runtimeEnv();
@@ -76,18 +76,18 @@ it('should return nextConfig with mocked variables alongside existing ones', () 
     });
 
     expect(nextConfig).toEqual({
-        publicRuntimeConfig: { PUBLIC_TEST_FOO: 'foo', foo: 'foo' },
-        serverRuntimeConfig: { SERVER_TEST_BAR: 'bar', bar: 'bar' },
-        env: { BUILD_TEST_ZOO: 'pet', zoo: 'zoo' },
+        publicRuntimeConfig: { NEXT_PUBLIC_TEST_FOO: 'foo', foo: 'foo' },
+        serverRuntimeConfig: { NEXT_SERVER_TEST_BAR: 'bar', bar: 'bar' },
+        env: { NEXT_BUILD_TEST_ZOO: 'pet', zoo: 'zoo' },
     });
 });
 
 it('should return existing nextConfig and extend it', () => {
     process.env = {
         ...originalEnv,
-        PUBLIC_TEST_FOO: 'foo',
-        SERVER_TEST_BAR: 'bar',
-        BUILD_TEST_ZOO: 'pet',
+        NEXT_PUBLIC_TEST_FOO: 'foo',
+        NEXT_SERVER_TEST_BAR: 'bar',
+        NEXT_BUILD_TEST_ZOO: 'pet',
     };
 
     const mockNextConfig = {
@@ -99,68 +99,60 @@ it('should return existing nextConfig and extend it', () => {
 
     expect(nextConfig).toEqual({
         ...mockNextConfig,
-        publicRuntimeConfig: { PUBLIC_TEST_FOO: 'foo' },
-        serverRuntimeConfig: { SERVER_TEST_BAR: 'bar' },
-        env: { BUILD_TEST_ZOO: 'pet' },
+        publicRuntimeConfig: { NEXT_PUBLIC_TEST_FOO: 'foo' },
+        serverRuntimeConfig: { NEXT_SERVER_TEST_BAR: 'bar' },
+        env: { NEXT_BUILD_TEST_ZOO: 'pet' },
     });
 });
 
-describe('when there are no environment variables', () => {
-    it('should return the default values', () => {
-        process.env = { };
+it('should return the default values when there are no environment variables', () => {
+    process.env = { };
 
-        const plugin = runtimeEnv();
-        const nextConfig = plugin();
+    const plugin = runtimeEnv();
+    const nextConfig = plugin();
 
-        expect(nextConfig).toEqual({
-            publicRuntimeConfig: {},
-            serverRuntimeConfig: {},
-            env: {},
-        });
+    expect(nextConfig).toEqual({
+        publicRuntimeConfig: {},
+        serverRuntimeConfig: {},
+        env: {},
     });
 });
 
-describe('when there is only the public config defined', () => {
-    it('should return the default values for the others', () => {
-        process.env = { PUBLIC_TEST_FOO: 'bar' };
+it('should return the default values for the others when there is only the public config defined', () => {
+    process.env = { NEXT_PUBLIC_TEST_FOO: 'bar' };
 
-        const plugin = runtimeEnv();
-        const nextConfig = plugin();
+    const plugin = runtimeEnv();
+    const nextConfig = plugin();
 
-        expect(nextConfig).toEqual({
-            publicRuntimeConfig: { PUBLIC_TEST_FOO: 'bar' },
-            serverRuntimeConfig: {},
-            env: {},
-        });
+    expect(nextConfig).toEqual({
+        publicRuntimeConfig: { NEXT_PUBLIC_TEST_FOO: 'bar' },
+        serverRuntimeConfig: {},
+        env: {},
     });
 });
 
-describe('when there is only the server config defined', () => {
-    it('should return the default values for the others', () => {
-        process.env = { SERVER_TEST_FOO: 'bar' };
+it('should return the default values for the others when there is only the server config defined', () => {
+    process.env = { NEXT_SERVER_TEST_FOO: 'bar' };
 
-        const plugin = runtimeEnv();
-        const nextConfig = plugin();
+    const plugin = runtimeEnv();
+    const nextConfig = plugin();
 
-        expect(nextConfig).toEqual({
-            publicRuntimeConfig: {},
-            serverRuntimeConfig: { SERVER_TEST_FOO: 'bar' },
-            env: {},
-        });
+    expect(nextConfig).toEqual({
+        publicRuntimeConfig: {},
+        serverRuntimeConfig: { NEXT_SERVER_TEST_FOO: 'bar' },
+        env: {},
     });
 });
 
-describe('when there is only the build config defined', () => {
-    it('should return the default values for the others', () => {
-        process.env = { BUILD_TEST_FOO: 'bar' };
+it('should return the default values for the others when there is only the build config defined', () => {
+    process.env = { NEXT_BUILD_TEST_FOO: 'bar' };
 
-        const plugin = runtimeEnv();
-        const nextConfig = plugin();
+    const plugin = runtimeEnv();
+    const nextConfig = plugin();
 
-        expect(nextConfig).toEqual({
-            publicRuntimeConfig: {},
-            serverRuntimeConfig: {},
-            env: { BUILD_TEST_FOO: 'bar' },
-        });
+    expect(nextConfig).toEqual({
+        publicRuntimeConfig: {},
+        serverRuntimeConfig: {},
+        env: { NEXT_BUILD_TEST_FOO: 'bar' },
     });
 });

--- a/index.test.js
+++ b/index.test.js
@@ -11,14 +11,16 @@ it('should return nextConfig with mocked variables', () => {
         ...originalEnv,
         PUBLIC_TEST_FOO: 'foo',
         SERVER_TEST_BAR: 'bar',
+        BUILD_TEST_ZOO: 'pet',
     };
 
     const plugin = runtimeEnv();
     const nextConfig = plugin();
 
-    expect(nextConfig).toMatchObject({
+    expect(nextConfig).toEqual({
         publicRuntimeConfig: { PUBLIC_TEST_FOO: 'foo' },
         serverRuntimeConfig: { SERVER_TEST_BAR: 'bar' },
+        env: { BUILD_TEST_ZOO: 'pet' },
     });
 });
 
@@ -27,14 +29,16 @@ it('should return nextConfig with mocked variables without prefix', () => {
         ...originalEnv,
         PUBLIC_TEST_FOO: 'foo',
         SERVER_TEST_BAR: 'bar',
+        BUILD_TEST_ZOO: 'pet',
     };
 
     const plugin = runtimeEnv({ removePrefixes: true });
     const nextConfig = plugin();
 
-    expect(nextConfig).toMatchObject({
+    expect(nextConfig).toEqual({
         publicRuntimeConfig: { TEST_FOO: 'foo' },
         serverRuntimeConfig: { TEST_BAR: 'bar' },
+        env: { TEST_ZOO: 'pet' },
     });
 });
 
@@ -43,14 +47,16 @@ it('should return nextConfig with mocked variables with new prefixes', () => {
         ...originalEnv,
         FOO_TEST_FOO: 'foo',
         BAR_TEST_BAR: 'bar',
+        ZOO_TEST_ZOO: 'pet',
     };
 
-    const plugin = runtimeEnv({ publicPrefix: 'FOO', serverPrefix: 'BAR' });
+    const plugin = runtimeEnv({ publicPrefix: 'FOO', serverPrefix: 'BAR', buildPrefix: 'ZOO' });
     const nextConfig = plugin();
 
-    expect(nextConfig).toMatchObject({
+    expect(nextConfig).toEqual({
         publicRuntimeConfig: { FOO_TEST_FOO: 'foo' },
         serverRuntimeConfig: { BAR_TEST_BAR: 'bar' },
+        env: { ZOO_TEST_ZOO: 'pet' },
     });
 });
 
@@ -59,25 +65,29 @@ it('should return nextConfig with mocked variables alongside existing ones', () 
         ...originalEnv,
         PUBLIC_TEST_FOO: 'foo',
         SERVER_TEST_BAR: 'bar',
+        BUILD_TEST_ZOO: 'pet',
     };
 
     const plugin = runtimeEnv();
     const nextConfig = plugin({
         publicRuntimeConfig: { foo: 'foo' },
         serverRuntimeConfig: { bar: 'bar' },
+        env: { zoo: 'zoo' },
     });
 
-    expect(nextConfig).toMatchObject({
+    expect(nextConfig).toEqual({
         publicRuntimeConfig: { PUBLIC_TEST_FOO: 'foo', foo: 'foo' },
         serverRuntimeConfig: { SERVER_TEST_BAR: 'bar', bar: 'bar' },
+        env: { BUILD_TEST_ZOO: 'pet', zoo: 'zoo' },
     });
 });
 
-it('should return extend existing nextConfig', () => {
+it('should return existing nextConfig and extend it', () => {
     process.env = {
         ...originalEnv,
         PUBLIC_TEST_FOO: 'foo',
         SERVER_TEST_BAR: 'bar',
+        BUILD_TEST_ZOO: 'pet',
     };
 
     const mockNextConfig = {
@@ -87,9 +97,70 @@ it('should return extend existing nextConfig', () => {
     const plugin = runtimeEnv();
     const nextConfig = plugin(mockNextConfig);
 
-    expect(nextConfig).toMatchObject({
+    expect(nextConfig).toEqual({
+        ...mockNextConfig,
         publicRuntimeConfig: { PUBLIC_TEST_FOO: 'foo' },
         serverRuntimeConfig: { SERVER_TEST_BAR: 'bar' },
-        ...mockNextConfig,
+        env: { BUILD_TEST_ZOO: 'pet' },
+    });
+});
+
+describe('when there are no environment variables', () => {
+    it('should return the default values', () => {
+        process.env = { };
+
+        const plugin = runtimeEnv();
+        const nextConfig = plugin();
+
+        expect(nextConfig).toEqual({
+            publicRuntimeConfig: {},
+            serverRuntimeConfig: {},
+            env: {},
+        });
+    });
+});
+
+describe('when there is only the public config defined', () => {
+    it('should return the default values for the others', () => {
+        process.env = { PUBLIC_TEST_FOO: 'bar' };
+
+        const plugin = runtimeEnv();
+        const nextConfig = plugin();
+
+        expect(nextConfig).toEqual({
+            publicRuntimeConfig: { PUBLIC_TEST_FOO: 'bar' },
+            serverRuntimeConfig: {},
+            env: {},
+        });
+    });
+});
+
+describe('when there is only the server config defined', () => {
+    it('should return the default values for the others', () => {
+        process.env = { SERVER_TEST_FOO: 'bar' };
+
+        const plugin = runtimeEnv();
+        const nextConfig = plugin();
+
+        expect(nextConfig).toEqual({
+            publicRuntimeConfig: {},
+            serverRuntimeConfig: { SERVER_TEST_FOO: 'bar' },
+            env: {},
+        });
+    });
+});
+
+describe('when there is only the build config defined', () => {
+    it('should return the default values for the others', () => {
+        process.env = { BUILD_TEST_FOO: 'bar' };
+
+        const plugin = runtimeEnv();
+        const nextConfig = plugin();
+
+        expect(nextConfig).toEqual({
+            publicRuntimeConfig: {},
+            serverRuntimeConfig: {},
+            env: { BUILD_TEST_FOO: 'bar' },
+        });
     });
 });


### PR DESCRIPTION
Problem: Currently, we only have this plugin to pass values from the environment to the application. However, this approach means that since we’re only passing values in runtime, we are not taking advantage of Dead Code Elimination that is performed in build time.

This PR aims to fix that.