### PR TITLE
feat:  Prevent env variables to be overriden when using removePrefixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ const buildConfig = (keys, initialConfig, prefix, { removePrefixes }) => {
         if (re.test(key)) {
             const name = removePrefixes ? key.replace(prefix, '') : key;
 
+            if (removePrefixes && process.env[name]) {
+                throw new Error(`Failed to override existing environment variable "${name}" while using the removePrefixes option. Please consider renaming the variable or changing the option.`);
+            }
+
             return {
                 ...acc,
                 [name]: process.env[key],

--- a/index.test.js
+++ b/index.test.js
@@ -156,3 +156,13 @@ it('should return the default values for the others when there is only the build
         env: { NEXT_BUILD_TEST_FOO: 'bar' },
     });
 });
+
+it('should not override existing process.env variables when the removeSuffix is activated', () => {
+    process.env = { FOO: 'dont replace me please', NEXT_PUBLIC_FOO: 'replaced :)' };
+
+    const plugin = runtimeEnv({ removePrefixes: true });
+
+    try { plugin(); } catch (e) {
+        expect(plugin).toThrowError(/^Failed to override existing environment variable "FOO"/);
+    }
+});


### PR DESCRIPTION
BREAKING CHANGE: When using "removePrefixes" as true, clashing environment properties will now throw an error.

Fixes: #9 

